### PR TITLE
BUG - Upgrades git plugin version

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -9,7 +9,7 @@ RUN mvn -f /usr/src/app/pom.xml package -DskipTests
 
 # --------------------------------------
 
-FROM jenkins/jenkins:lts-jdk11
+FROM jenkins/jenkins:2.289.3-jdk11
 USER root
 RUN apt-get update && apt-get install -y apt-transport-https \
     ca-certificates curl gnupg2 \
@@ -22,7 +22,7 @@ RUN add-apt-repository \
 RUN apt-get update && apt-get install -y docker-ce-cli
 
 USER jenkins
-RUN jenkins-plugin-cli --plugins "blueocean:1.24.7 docker-workflow:1.26 git:4.7.2 pipeline-as-yaml:0.16-rc locale:1.4 ssh-slaves:1.31.7 ssh-credentials:1.19 git:4.7.2 configuration-as-code:1.51 job-dsl:1.77"
+RUN jenkins-plugin-cli --plugins "sshd:3.1.0 blueocean:1.24.8 docker-workflow:1.26 git:4.8.1 pipeline-as-yaml:0.16-rc locale:1.4 ssh-slaves:1.31.7 ssh-credentials:1.19 configuration-as-code:1.51 job-dsl:1.77"
 
 USER root
 

--- a/jenkins/docker-compose.yml
+++ b/jenkins/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - JENKINS_EVA_SCRIPTS=/home/eva_scripts
       - CASC_JENKINS_CONFIG=/home/eva_scripts/casc_configs/jenkins.yaml
       - JENKINS_EVA_PLUGINS=/home/eva_plugins
+      - TRY_UPGRADE_IF_NO_MARKER=true
     volumes:
       - jenkins-data:/var/jenkins_home
       - jenkins-docker-certs:/certs/client
@@ -36,7 +37,7 @@ services:
     ports:
       - 22:22
     secrets:
-      - jenkins_eva_agent1_pub_key       
+      - jenkins_eva_agent1_pub_key
     depends_on:
       - jenkins
 
@@ -53,7 +54,6 @@ secrets:
     file: '.secrets/jenkins_eva_agent1_key.pub'
   jenkins_eva_agent1_key_password:
     file: '.secrets/jenkins_eva_agent1_key_password'
-
 
 volumes:
   jenkins-data:


### PR DESCRIPTION
- Upgrades git plugin to 4.8.1, as well as sshd to 3.1.0. 
- Adds flag to try to upgrade plugins so that 3.1.0 sshd version is used instead of 3.0.3

This fixes a problem that was not allowing to build jenkins image.